### PR TITLE
Relax requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python
+opencv-python-headless
 numpy
 matplotlib
 seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 opencv-python-headless
-numpy
 matplotlib
 seaborn
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ shapely
 scikit-learn
 tensorflow-gpu < 2.0
 scipy
-click
 ocrd >= 2.0.0


### PR DESCRIPTION
require `opencv-python-headless` instead of `opencv-python` (avoids pulling in X11)