### PR TITLE
Require opencv-python-headless instead of opencv-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python
+opencv-python-headless
 numpy
 matplotlib
 seaborn


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>