### PR TITLE
use TensorFlow 1.15.2 or later, but not 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ tqdm
 keras
 shapely
 scikit-learn
-tensorflow-gpu < 2.0
+tensorflow-gpu ~=1.15.2
 scipy
 ocrd >= 2.0.0


### PR DESCRIPTION
fix vuln [GHSA-977j-xj7q-2jr9](https://github.com/advisories/GHSA-977j-xj7q-2jr9)