### PR TITLE
ocrd-tool.json: Make description OCR-D compliant

### DIFF
--- a/qurator/sbb_textline_detector/ocrd-tool.json
+++ b/qurator/sbb_textline_detector/ocrd-tool.json
@@ -1,8 +1,10 @@
 {
   "version": "0.0.1",
+  "git_url": "https://github.com/qurator-spk/sbb_textline_detection",
   "tools": {
     "ocrd-sbb-textline-detector": {
       "executable": "ocrd-sbb-textline-detector",
+      "categories": ["Image preprocessing", "Layout analysis", "Text recognition and optimization"],
       "description": "Detect lines",
       "steps": ["layout/segmentation/line"],
       "input_file_grp": [
@@ -12,7 +14,12 @@
         "OCR-D-SBB-SEG-LINE"
       ],
       "parameters": {
-        "model": {"type": "string", "format": "file", "cacheable": true}
+        "model": {
+          "type": "string",
+          "format": "file",
+          "cacheable": true,
+          "description": "Path to directory containing models to be used (See https://qurator-data.de/sbb_textline_detector/)"
+        }
       }
     }
   }


### PR DESCRIPTION
Add missing required fields from the [OCR-D tool specification](https://ocr-d.de/en/spec/ocrd_tool) to `ocrd-tool.json`.

`ocrd ocrd-tool ocrd-tool.json validate` should now evaluate to "true".