### PR TITLE
Enforce older version of Keras which does not use TensorFlow 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ opencv-python-headless
 matplotlib
 seaborn
 tqdm
-keras
+keras == 2.3.*
 shapely
 scikit-learn
 tensorflow-gpu ~=1.15.2


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>