### PR TITLE
🐛 sbb_textline_detection: Fix qurator namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     keywords='qurator',
     license='Apache',
     url="https://qurator.ai",
+    namespace_packages=['qurator'],
     packages=find_packages(exclude=["*.tests", "*.tests.*",
                                     "tests.*", "tests"]),
     install_requires=install_requires,


### PR DESCRIPTION
Set namespace_packages in setup.py. This fixes installation problems reported by @kba.

I have no idea why this does not happen with my installation tests on Python 3.7. I don't know what I am doing, but this fixes it.