### PR TITLE
🐛 Work around not detecting any regions (and lines) with OpenCV 4.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python-headless
+opencv-python-headless < 4.6  # XXX https://github.com/qurator-spk/sbb_textline_detection/issues/60
 matplotlib
 seaborn
 tqdm


### PR DESCRIPTION
Using opencv-python-headless 4.6.x we get the following error when detecting the contours of the detected text regions:

module 'cv2' has no attribute 'cv2'

Work around this by requiring OpenCV < 4.6 for now. See also the discussion at
https://github.com/qurator-spk/sbb_textline_detection/issues/60.

Fixes gh-60.