### PR TITLE
🐛 Don't test on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@
 dist: xenial  # required for Python >= 3.7
 language: python
 python:
-  # sbb_textline_detector requires Python 3.6 or newer
+  # sbb_textline_detector requires Python 3.6
   - "3.6"
-  - "3.7"
+  # broken on Python 3.7 (and never supposed to work)
   # tensorflow-gpu<2.0 is not available for Python 3.8
 
 install:


### PR DESCRIPTION
I believe this was never supposed to work on Python 3.7 and there some problems with it:

https://github.com/qurator-spk/sbb_textline_detection/issues/64

"Fix" this by removing the test on Python 3.7. Fixes gh-64.